### PR TITLE
[ADD] Video page API View, Test

### DIFF
--- a/courses/tests.py
+++ b/courses/tests.py
@@ -1,13 +1,12 @@
-import json
 import re
 
-from django.http.request import HttpRequest
-from django.test.client import Client
-from courses.views       import VideoPlayer
-from django.test         import TestCase
+from django.http.request    import HttpRequest
+from django.test.client     import Client
+from django.test            import TestCase
 
-from courses.models import SubCategory, Category, Course, Hashtag 
-
+from courses.views          import VideoPlayer, VideoLayoutView
+from courses.models         import Category, Lecture, LectureCompletion, Level, Section, Course, SubCategory, Hashtag
+from users.models           import User
 class VideoPlayerTest(TestCase) :
     test_cls = VideoPlayer()
     test_req = HttpRequest()
@@ -177,3 +176,175 @@ class CategoryViewTest(TestCase):
             } for category in Category.objects.all()] 
             } 
         )
+class VideoLayoutTest(TestCase) :
+    INSTANCE = VideoLayoutView()
+
+
+    def setUp(self):
+        User.objects.create(
+            id          = 1,
+            nickname    = "test_name",
+            email       = "test1@sample.com",
+            phone_number= "010-0000-0000",
+            introduce   = "",
+            sharer      = 1            
+        )
+
+        Level.objects.create(
+            id          = 1,
+            name        = "test_level"
+        )
+        
+        Category.objects.create(
+            id          = 1,
+            name        = "test_cate"
+        )
+
+        SubCategory.objects.create(
+            id          = 1,
+            name        = "test_subcate",
+            category_id = 1
+        )
+
+        Course.objects.create(
+            id                      = 1,
+            name                    = "test_course",
+            summary                 = "summary",
+            detail                  = "detail",
+            thumbnail_url           = "url",
+            visible                 = 1,
+            price                   = 77000,
+            learning_period_month   = 999,
+            level_id                = 1,
+            sharer_id               = 1,
+            subcategory_id          = 1
+        )
+
+        Course.objects.create(
+            id                      = 999,
+            name                    = "test_course",
+            summary                 = "summary",
+            detail                  = "detail",
+            thumbnail_url           = "url",
+            visible                 = 1,
+            price                   = 77000,
+            learning_period_month   = 999,
+            level_id                = 1,
+            sharer_id               = 1,
+            subcategory_id          = 1
+        )
+
+        Section.objects.create(
+            id          = 1,
+            name        = "test_section",
+            priority    = 1,
+            course_id   = 1
+        )
+
+        Lecture.objects.create(
+            id           = 1,
+            name         = "test_lecture",
+            storage_key  = "blank",
+            storage_path = "https://www.naver.com",
+            priority     = 1,
+            play_time    = 120,
+            section_id   = 1      
+        )
+
+        LectureCompletion.objects.create(
+            id          = 1,
+            user_id     = 1,
+            lecture_id  = 1
+        )
+
+    def tearDown(self) :
+        User.objects.all().delete()
+        Category.objects.all().delete()
+        SubCategory.objects.all().delete()
+        Level.objects.all().delete()
+        Course.objects.all().delete()
+        Section.objects.all().delete()
+        Lecture.objects.all().delete()
+        LectureCompletion.objects.all().delete()
+
+    def test_success_get_user_id(self) :
+        request  = HttpRequest()
+        request.META["HTTP_Authorization"] = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6MX0.jSxa98uKu7i-QAszAY0wdZVh3VrriKqvh12cSWEQZ_w'
+        self.assertEqual(self.INSTANCE.get_user_id(request), 1)
+
+    def test_fail_get_user_id_no_token(self) :
+        request  = HttpRequest()
+        self.assertEqual(self.INSTANCE.get_user_id(request), False)
+    
+    def test_success_get_S_list(self) :
+        lectures = Lecture.objects.select_related("section").values("section__id","section__name")
+        self.assertEqual(self.INSTANCE.get_S_list(lectures),[(1,'test_section')])
+
+    def test_fail_get_S_list_key_error(self) :
+        lectures = Lecture.objects.select_related("section").values("section__name").filter(id=1)
+        self.assertEqual(self.INSTANCE.get_S_list(lectures),False)
+
+    def test_success_check_user_finished_lecture(self) :
+        course_id   = 1
+        user_id     = 1
+        result = {
+            "section_list" : [{
+                "lecture_list" : [{
+                    "lecture_id" : 1,
+                    "finished" : 0
+                }]
+            }]
+        }
+        self.assertEqual(self.INSTANCE.check_user_finished_lecture(course_id,result,user_id),
+            (True,{
+                    "section_list" : [{
+                        "lecture_list" : [{
+                            "lecture_id" : 1,
+                            "finished" : 1
+                        }]
+                    }]
+                }))
+            
+    def test_fail_check_user_finished_lecture(self) :
+        course_id   = 1
+        user_id     = 1
+        result = {}
+        self.assertEqual(self.INSTANCE.check_user_finished_lecture(course_id,result, user_id),
+        (False, "Key error in result"))
+
+    def test_success_get(self) :
+        client = Client()
+        resp = client.get('/course/video/1')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {
+            "course_id": 1,
+            "course_name": "test_course",
+            "period": 999,
+            "section_legnth": 1,
+            "section_list": [
+                {
+                    "setion_id": 1,
+                    "section_name": "test_section",
+                    "lecture_list": [
+                        {
+                            "lecture_id": 1,
+                            "lecture_name": "test_lecture",
+                            "lecture_video_url": "https://www.naver.com",
+                            "lecture_runtime": 120,
+                            "finished": 0
+                        }]
+                }]
+        })
+
+    def test_fail_get_course_index_out_of_range(self) :
+        client = Client()
+        resp = client.get('/course/video/9999')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json(), {"MESSAGE" : "invalid_course_id"})
+
+    def test_fail_get_course_no_lecture(self) :
+        client = Client()
+        resp = client.get('/course/video/999')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json(), {"MESSAGE" : "no_lecture_in_course"})
+    

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -1,7 +1,9 @@
 from django.urls    import path
-from courses.views  import VideoPlayer, CategoryListView
+from courses.views  import VideoPlayer, CategoryListView, VideoLayoutView, LectureDetail
 
 urlpatterns = [
     path('/categories', CategoryListView.as_view()),
-    path('/<path>', VideoPlayer.as_view()), #이것도 의논해야함
-    ]
+    path('/video/<int:course_id>', VideoLayoutView.as_view()),
+    path('/video/detail/<int:lecture_id>', LectureDetail.as_view()),
+    path('/<path>', VideoPlayer.as_view())
+]

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,16 +1,16 @@
 import os
 import re
 import mimetypes
+import jwt
+from wsgiref.util           import FileWrapper
+from django.http            import JsonResponse, StreamingHttpResponse
+from django.http.response   import HttpResponse
+from django.views           import View 
+from django.db.models       import Q, Avg
 
-from wsgiref.util   import FileWrapper
-
-from django.http    import JsonResponse, StreamingHttpResponse
-from django.http.response import HttpResponse
-from django.views   import View 
-from django.db.models import Q, Avg
-
-from courses.models import Category, Course, SubCategory, Hashtag
-
+from ifLearn.settings       import SECRET_KEY, ALGORITHM
+from courses.models         import Category, Course, Hashtag, Lecture, LectureCompletion
+from users.models           import User
 
 
 class RangeFileWrapper:
@@ -108,3 +108,117 @@ class CategoryListView(View):
             } for category in categories]
         
         return JsonResponse({"result" : result}, status = 200)
+
+class VideoLayoutView(View) :
+    def get_user_id(self,request) :
+        if "Authorization" in request.headers :
+            access_token = request.headers.get('Authorization')
+            payload      = jwt.decode(access_token, SECRET_KEY, ALGORITHM)
+            login_user_id= User.objects.get(id=payload['id']).id
+            return login_user_id
+
+        else : return False
+    
+    def get_S_list(self,lectures) :
+        try :
+            S_id_list = [(L["section__id"],L["section__name"]) for L in lectures]
+            S_id_list = list(set(S_id_list))
+            S_id_list.sort()
+            return S_id_list
+        except KeyError :
+            return False
+
+    def check_user_finished_lecture(self,course_id, result,user_id) :
+        try :
+            finish_queryset = LectureCompletion.objects.select_related("lecture__section__course"
+                ).values("lecture_id", "lecture__section__course__id"
+                ).filter(lecture__section__course__id=course_id, user_id=user_id)
+
+            finish_list = [F["lecture_id"] for F in finish_queryset]
+
+            for section in result["section_list"] :
+                for lecture in section["lecture_list"] :
+                    if lecture["lecture_id"] in finish_list :
+                        lecture["finished"] = 1
+            
+            return (True, result)
+        except KeyError :
+            return (False, "Key error in result")
+
+    key_match = {
+        "course_id" : "section__course__id",
+        "course_name" : "section__course__name",
+        "period" : "section__course__learning_period_month",
+        "setion_id" : "section__id",
+        "section_name" : "section__name",
+        "lecture_id" : "id",
+        "lecture_name" : "name",
+        "lecture_video_url" : "storage_path",
+        "lecture_runtime" : "play_time"
+    }
+
+    def get(self,request,course_id) :
+        lectures    = Lecture.objects.select_related('section', 'section__course').values(
+            *[self.key_match[key] for key in self.key_match]
+            ).prefetch_related('lecture_completion_by_lecture'
+            ).filter(section__course__id=course_id)
+        
+        if lectures.count() == 0 :
+            course_get = Course.objects.filter(id=course_id)
+            if not course_get.exists() :
+                return JsonResponse({"MESSAGE" : "invalid_course_id"}, status=400)
+            return JsonResponse({"MESSAGE" : "no_lecture_in_course"}, status=400)
+
+        
+        S_id_list   = self.get_S_list(lectures)
+        _L          = lectures[0]
+        
+        result = {
+            "course_id"      : _L[self.key_match["course_id"]],
+            "course_name"    : _L[self.key_match["course_name"]],
+            "period"         : _L[self.key_match["period"]],
+            "section_legnth" : len(lectures),
+            "section_list"   : [{
+                "setion_id"     : S[0],
+                "section_name"  : S[1],
+                "lecture_list"  : [{
+                    "lecture_id"        : L[self.key_match["lecture_id"]],
+                    "lecture_name"      : L[self.key_match["lecture_name"]],
+                    "lecture_video_url" : L[self.key_match["lecture_video_url"]],
+                    "lecture_runtime"   : L[self.key_match["lecture_runtime"]],
+                    "finished"          : 0
+                } for L in lectures if L["section__id"] == S[0]]
+            } for S in S_id_list]
+        }
+
+        user_id = self.get_user_id(request)
+        if user_id : 
+            boolean, message = self.check_user_finished_lecture(course_id, result, user_id)
+            if boolean :
+                result = message
+
+        return JsonResponse(result)
+
+class LectureDetail(View) :
+    def get_user_id(self,request) :
+        if "Authorization" in request.headers :
+            access_token = request.headers.get('Authorization')
+            payload      = jwt.decode(access_token, SECRET_KEY, ALGORITHM)
+            login_user_id= User.objects.get(id=payload['id']).id
+            return login_user_id
+
+        else : return False
+
+    def get(self,request,lecture_id) :
+        lecture         = Lecture.objects.get(id=lecture_id)
+        user_id         = self.get_user_id(request)
+        finish_queryset = LectureCompletion.objects.values('user_id', 'lecture_id'
+        ).filter(user_id=user_id,lecture_id=lecture_id)
+
+        return JsonResponse({
+            "lecture_id"        : lecture.id,
+            "lecture_name"      : lecture.name,
+            "lecture_video_url" : lecture.storage_path,
+            "lecture_runtime"   : lecture.play_time,
+            "finished"          : int(finish_queryset.exists())
+        }, status= 200)


### PR DESCRIPTION
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 스트리밍 페이지 내에 필요한 API 제공

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
### 렉쳐목록 불러오기 (강의 기준)
- { 코스정보, 섹션리스트 : [{섹션정보, 렉쳐 리스트:[랙쳐 정보]}]} 의 형태로 API 반환
- 존재하는 코스인지 확인
- 코스가 있다면, lecture가 존재하는지 확인

### 로그인 입력 데이터 유효성 
- 헤더에 액세스 토큰이 있는지 확인한다. 없으면 아래의 동작을 하지 않는다.
- 액세스 토큰으로 user의 id값을 확인한다.
- 강의 완료 Table에서, user의 id를 기준으로 완료한 Lecture가 있는지 체크해서 반환한다.

### 유닛테스트 작성
- 로그인 확인, 완료여부 확인을 함수로 구분하여 유닛테스트 작성
- 전체 데이터에 대한 유닛테스트 작성

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- DB와의 접속을 최소화 하는 방향으로 코드를 작성할 수 있었습니다.
- 데이터가 필요한 유닛테스트를 만들면서 id 값이 자동으로 생성되지 않아 꼭 직접 넣어줘야 함을 배웠습니다.
- 프론트 쪽에서 필요한 데이터의 형태를 배울 수 있었습니다.
- 협업을 하며 발생하는 충돌을 해결하며, 의사소통의 중요성을 배웠습니다.

<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 
